### PR TITLE
Commented the controller vars so the group_vars/all are taken instead

### DIFF
--- a/group_vars/controller
+++ b/group_vars/controller
@@ -1,8 +1,8 @@
 ---
 # vi:syntax=yaml
-remote_user: "heat-admin"
-become: "True"
-result_dir: "{{inventory_dir}}/results"
+#remote_user: "heat-admin"
+#become: "True"
+#result_dir: "{{inventory_dir}}/results"
 #result_dir: "/home/stack/"
 
 controller_checks:


### PR DESCRIPTION
Hi,

a rather small thingy but when trying out the script the first time it was a bit confusing, following the readme there is the section of the group_vars/all so I assumed both controller and compute nodes where going to use those. 

But the controller is using the group_vars/controller instead since they aren't commented out as the group_vars/compute file. 

Not sure if that's intended behaviour but thought it couldn't harm to mention it here